### PR TITLE
Address IE 11 compat and SMART v1 PKCE override

### DIFF
--- a/src/security/index.ts
+++ b/src/security/index.ts
@@ -12,23 +12,16 @@ declare var IS_BROWSER: boolean;
 let wcrypto: SubtleCrypto;
 let cryptoRandomBytes: (count: number) => Uint8Array;
 
-if (typeof IS_BROWSER == 'undefined' && (typeof window === 'undefined' || !window?.crypto?.subtle)) {
+if (typeof IS_BROWSER == 'undefined' && (typeof window === 'undefined')) {
   wcrypto =  require('crypto').webcrypto.subtle
   cryptoRandomBytes = require('crypto').randomBytes
 } else {
-  wcrypto = window.crypto.subtle
+  const wcryptoBase = window.crypto || window.msCrypto; // for IE11
+  wcrypto = wcryptoBase.subtle || wcryptoBase.webkitSubtle; // for Safari
 }
 
-export const digestSha256 = async (payload: string | ArrayBuffer) => {
-  let prepared: ArrayBuffer;
-
-  if (typeof payload === 'string') {
-    const encoder = new TextEncoder();
-    prepared = encoder.encode(payload).buffer;
-  } else {
-      prepared = payload
-  }
-
+const digestSha256 = async (payload: string) => {
+  const prepared: ArrayBuffer = new Uint8Array(payload.split('').map(s => s.charCodeAt(0)));
   const hash = await wcrypto.digest('SHA-256', prepared);
   return new Uint8Array(hash);
 }

--- a/src/smart.ts
+++ b/src/smart.ts
@@ -383,7 +383,7 @@ export async function authorize(
       throw new Error("Required PKCE code challenge method (`S256`) was not found.");
     }
 
-    if ((pkceMode !== 'disabled') && (extensions.codeChallengeMethods.includes('S256'))) {
+    if ((pkceMode == 'unsafeV1') || ((pkceMode !== 'disabled') && (extensions.codeChallengeMethods.includes('S256')))) {
       let codes = await security.generatePKCEChallenge()
       Object.assign(state, codes);
       await storage.set(stateKey, state); // note that the challenge is ALREADY encoded properly

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -216,7 +216,7 @@ declare namespace fhirclient {
     function WindowTargetFunction(): Promise<WindowTargetVariable>;
     type WindowTarget = WindowTargetVariable | typeof WindowTargetFunction;
 
-    type PkceMode = 'ifSupported' | 'required' | 'disabled';
+    type PkceMode = 'ifSupported' | 'required' | 'disabled' | 'unsafeV1';
 
     type storageFactory = (options?: Record<string, any>) => Storage;
 
@@ -605,6 +605,7 @@ declare namespace fhirclient {
          * - `ifSupported` Use if a matching code challenge method is available (**default**)
          * - `required`    Do not attempt authorization to servers without support
          * - `disabled`    Do not use PKCE
+         * - `unsafeV1`    Use against Smart v1 servers. Smart v1 does not define conformance, so validate your server supports PKCE before using this setting
          */
          pkceMode?: PkceMode;
       }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -4,12 +4,23 @@ import Client from "./Client";
 import { getPath, byCodes, byCode } from "./lib";
 import { IncomingMessage } from "http";
 
+declare global {
+    interface Window {
+        msCrypto: Crypto;
+    }
+    interface Crypto {
+        webkitSubtle: SubtleCrypto
+    }
+  }
+
 // tslint:disable-next-line: no-namespace
 declare namespace fhirclient {
 
     interface RequestWithSession extends IncomingMessage {
         session: fhirclient.JsonObject;
     }
+
+
 
     interface SMART {
         options: BrowserFHIRSettings;


### PR DESCRIPTION
Made some tweaks to address these items:

- [X] IE-11 doesn't follow the current webcrpyto standard. The Crypto object is actually located at `window.msCrypto`. I'm calling to that as a fallback whenever `window.crypto` isn't present. I did something similar with `window.crypto.webkitSubtle` as a fallback for `window.crypto.subtle`. I found this information in the [webcrypto-shim](https://github.com/vibornoff/webcrypto-shim) repo, whose author also had a nice [support matrix](https://vibornoff.github.io/webcrypto-examples/index.html) app you could run in your browser.

- [X] Vlad's point that IE-11 [doesn't support TextEncoder](https://github.com/smart-on-fhir/client-js/pull/147#discussion_r918929412). In the first commit I do a couple things to address this:

1. I no longer export the digestsha256 function, since nothing else was calling it
2. I assume the function is only ever going to accept b64url encoded strings (so no UTF-8 to worry about). Under this assumption I was able to write a very short version of text encoder that splits the string and gets the character code for each character

- [X] My [comment](https://github.com/smart-on-fhir/client-js/pull/147#issuecomment-1099512716) about PKCE not triggering against SMART v1 servers, since SMART v1 doesn't include `code_challenge_methods_supported` in conformance. To address this, I created a pkceMode of `unsafeV1` that allows clients to manually force the library to include the PKCE parameters. I'd be open to including a warning when this setting is used, but have not included that for now

I've tested the functions in a vacuum in IE-11 but haven't been able to get everything bundled into an example app that runs without syntax errors.... Would appreciate anyone with more experience trying that out in Epic's embedded browser testing harness, which you can attach developer tools to by looking for "F12" in your windows + R run prompt. My path is `C:\Windows\System32\F12\IEChooser.exe` for example.
